### PR TITLE
[Sprint 72] Atualiza versão do mysql de 5.7 para 8.0 no avaliador

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: 'password'
         ports:


### PR DESCRIPTION
Na introdução a MYSQl é ensinado instalar o MYSQL na versão 8.0.23 porém a versão do avaliador esta na versão 5.7. Uma pessoa estudante da turma 8 teve um conflito por causa disso.

[Link da issue 🔗 ](https://github.com/betrybe/course/issues/4640)